### PR TITLE
Fixes the transition on load in chrome

### DIFF
--- a/scripts/landing.js
+++ b/scripts/landing.js
@@ -8,8 +8,11 @@ function revealPoints(i) {
     }
 
 document.addEventListener("DOMContentLoaded", function(){ 
-for (var i = 0; i < points.length; i++) {
-    revealPoints(i);
-}
+  for (var i = 0; i < points.length; i++) {
+    (function(n){
+    setTimeout(function(){
+      revealPoints(n);
+    }, 10);
+    })(i);
+  }
 });
-


### PR DESCRIPTION
Here's a fix for the transitions on load Joel.

FYI, it worked in Firefox (even before the fix) and I'm not certain why this particular fix is necessary. I would suggest moving on.
